### PR TITLE
Add babel-plugin-syntax-trailing-function-commas

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,7 @@
   },
   "plugins": [
     "transform-runtime",
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "syntax-trailing-function-commas"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-core": "^6.8.0",
     "babel-eslint": "^6.0.4",
     "babel-loader": "^6.2.4",
+    "babel-plugin-syntax-trailing-function-commas": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-plugin-transform-runtime": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",


### PR DESCRIPTION
Add [syntax-tralling-function-commas plugin](https://babeljs.io/docs/plugins/syntax-trailing-function-commas/)
